### PR TITLE
BohemianCoding/Sketch#3319 Script import: Add support for absolute and ~ paths

### DIFF
--- a/src/framework/COSPreprocessor.m
+++ b/src/framework/COSPreprocessor.m
@@ -220,21 +220,25 @@
                     NSString *path = [[pathInQuotes substringWithRange:NSMakeRange(1, [pathInQuotes length]-2)] stringByExpandingTildeInPath];
                     NSURL *importURL = nil;
                     
-                    if (base && path.length && ![[path substringWithRange:NSMakeRange(0, 1)] isEqualToString:@"/"]) {
+                    if (path.length && ![[path substringWithRange:NSMakeRange(0, 1)] isEqualToString:@"/"]) {
                         importURL = [[base URLByDeletingLastPathComponent] URLByAppendingPathComponent:path];
-                    } else {
+                    } else if (base) {
                         importURL = [NSURL fileURLWithPath:path];
+                    } else {
+                        [buffer appendFormat:@"'Unable to import %@ becase we have no base url to import from'", path];
                     }
                     
-                    NSError *outErr = nil;
-                    NSString *s = [NSString stringWithContentsOfURL:importURL encoding:NSUTF8StringEncoding error:&outErr];
-                    
-                    if (s) {
-                        [buffer appendFormat:@"// imported from %@", [importURL path]];
-                        [buffer appendString:s];
-                    }
-                    else {
-                        [buffer appendFormat:@"'Unable to import %@ because %@'", path, [outErr localizedFailureReason]];
+                    if (importURL) {
+                        NSError *outErr = nil;
+                        NSString *s = [NSString stringWithContentsOfURL:importURL encoding:NSUTF8StringEncoding error:&outErr];
+                        
+                        if (s) {
+                            [buffer appendFormat:@"// imported from %@", [importURL path]];
+                            [buffer appendString:s];
+                        }
+                        else {
+                            [buffer appendFormat:@"'Unable to import %@ because %@'", path, [outErr localizedFailureReason]];
+                        }                        
                     }
                     
                     debug(@"[tok stringValue]: '%@'", path);

--- a/src/framework/COSPreprocessor.m
+++ b/src/framework/COSPreprocessor.m
@@ -217,33 +217,27 @@
                     [tokenizer nextToken]; // the space
                     NSString *pathInQuotes = [[tokenizer nextToken] stringValue];
                     
-                    NSString *path = [pathInQuotes substringWithRange:NSMakeRange(1, [pathInQuotes length]-2)];
+                    NSString *path = [[pathInQuotes substringWithRange:NSMakeRange(1, [pathInQuotes length]-2)] stringByExpandingTildeInPath];
+                    NSURL *importURL = nil;
                     
-                    if (base) {
-                        
-                        NSURL *importURL = [[base URLByDeletingLastPathComponent] URLByAppendingPathComponent:path];
-                        
-                        NSError *outErr = nil;
-                        NSString *s = [NSString stringWithContentsOfURL:importURL encoding:NSUTF8StringEncoding error:&outErr];
-                        
-                        if (s) {
-                            [buffer appendFormat:@"// imported from %@", [importURL path]];
-                            [buffer appendString:s];
-                        }
-                        else {
-                            [buffer appendFormat:@"'Unable to import %@ becase %@'", path, [outErr localizedFailureReason]];
-                        }
-                        
-                        
-                        //debug(@"importURL: '%@'", importURL);
-                        
+                    if (base && path.length && ![[path substringWithRange:NSMakeRange(0, 1)] isEqualToString:@"/"]) {
+                        importURL = [[base URLByDeletingLastPathComponent] URLByAppendingPathComponent:path];
+                    } else {
+                        importURL = [NSURL fileURLWithPath:path];
+                    }
+                    
+                    NSError *outErr = nil;
+                    NSString *s = [NSString stringWithContentsOfURL:importURL encoding:NSUTF8StringEncoding error:&outErr];
+                    
+                    if (s) {
+                        [buffer appendFormat:@"// imported from %@", [importURL path]];
+                        [buffer appendString:s];
                     }
                     else {
-                        [buffer appendFormat:@"'Unable to import %@ becase we have no base url to import from'", path];
+                        [buffer appendFormat:@"'Unable to import %@ because %@'", path, [outErr localizedFailureReason]];
                     }
                     
                     debug(@"[tok stringValue]: '%@'", path);
-                    
                     
                     continue;
                 }


### PR DESCRIPTION
Import paths can be in the format:

```
relative/to/script.js
/absolute/path/to/script.js
~/relative/to/home/script.js
```

Ref BohemianCoding/Sketch#3319
