### PR TITLE
Code Review: Allow scripts to register for individual actions (#8195)

### DIFF
--- a/Cocoa Script.xcodeproj/project.pbxproj
+++ b/Cocoa Script.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		220D93E71C92E69C001EF05C /* JSTTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = CC66D8CD181A2E2F0039A0A5 /* JSTTextView.m */; };
+		220D93E81C92E75A001EF05C /* JSTTextView.h in Headers */ = {isa = PBXBuildFile; fileRef = CC66D8CC181A2E2F0039A0A5 /* JSTTextView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		384830E21832D48500B34168 /* COSTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = 384830E01832D48500B34168 /* COSTarget.h */; };
 		384830E31832D48500B34168 /* COSTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 384830E11832D48500B34168 /* COSTarget.m */; };
 		8D15AC340486D014006FF6A4 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A7FEA54F5311CA2CBB /* Cocoa.framework */; };
@@ -1207,6 +1209,7 @@
 				CC66D8B2181A2B0A0039A0A5 /* MOPointer_Private.h in Headers */,
 				CCA1A535183EA86E000159B3 /* COSInterval.h in Headers */,
 				CC66D8BC181A2B0A0039A0A5 /* MOStruct.h in Headers */,
+				220D93E81C92E75A001EF05C /* JSTTextView.h in Headers */,
 				CC66D7D5181A2A470039A0A5 /* TDMultiLineCommentState.h in Headers */,
 				CC66D7BD181A2A470039A0A5 /* TDAssembly.h in Headers */,
 				CCE675E8182ED9C900DB1932 /* COSAlertWindow.h in Headers */,
@@ -1486,6 +1489,7 @@
 				CC66D7E5181A2A470039A0A5 /* TDReader.m in Sources */,
 				CC66D7D6181A2A470039A0A5 /* TDMultiLineCommentState.m in Sources */,
 				CC66D8B1181A2B0A0039A0A5 /* MOObjCRuntime.m in Sources */,
+				220D93E71C92E69C001EF05C /* JSTTextView.m in Sources */,
 				CC07AF4D1982C310001CCA93 /* COSMarkdown.m in Sources */,
 				CC66D807181A2A470039A0A5 /* TDTokenizerState.m in Sources */,
 				CC66D84F181A2AB10039A0A5 /* MOBridgeSupportSymbol.m in Sources */,

--- a/src/editor/JSTTextView.m
+++ b/src/editor/JSTTextView.m
@@ -169,7 +169,9 @@ static NSString *JSTQuotedStringAttributeName = @"JSTQuotedString";
 
 
 - (void)textStorage:(NSTextStorage *)textStorage didProcessEditing:(NSTextStorageEditActions)editedMask range:(NSRange)editedRange changeInLength:(NSInteger)delta {
-    [self parseCode:nil];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self parseCode:nil];
+    });
 }
 
 - (NSArray *)writablePasteboardTypes {

--- a/src/editor/JSTTextView.m
+++ b/src/editor/JSTTextView.m
@@ -168,8 +168,7 @@ static NSString *JSTQuotedStringAttributeName = @"JSTQuotedString";
 }
 
 
-
-- (void) textStorageDidProcessEditing:(NSNotification *)note {
+- (void)textStorage:(NSTextStorage *)textStorage didProcessEditing:(NSTextStorageEditActions)editedMask range:(NSRange)editedRange changeInLength:(NSInteger)delta {
     [self parseCode:nil];
 }
 
@@ -188,22 +187,22 @@ static NSString *JSTQuotedStringAttributeName = @"JSTQuotedString";
     
 }
 
-- (void)insertText:(id)insertString {
-    
+- (void)insertText:(id)insertString replacementRange:(NSRange)replacementRange {
+
     if (!([JSTPrefs boolForKey:@"codeCompletionEnabled"])) {
-        [super insertText:insertString];
+        [super insertText:insertString replacementRange:replacementRange];
         return;
     }
     
     // make sure we're not doing anything fance in a quoted string.
-    if (NSMaxRange([self selectedRange]) < [[self textStorage] length] && [[[self textStorage] attributesAtIndex:[self selectedRange].location effectiveRange:nil] objectForKey:JSTQuotedStringAttributeName]) {
-        [super insertText:insertString];
+    if (NSMaxRange(replacementRange) < [[self textStorage] length] && [[[self textStorage] attributesAtIndex:replacementRange.location effectiveRange:nil] objectForKey:JSTQuotedStringAttributeName]) {
+        [super insertText:insertString replacementRange:replacementRange];
         return;
     }
     
     if ([@")" isEqualToString:insertString] && [_lastAutoInsert isEqualToString:@")"]) {
         
-        NSRange nextRange   = [self selectedRange];
+        NSRange nextRange   = replacementRange;
         nextRange.length = 1;
         
         if (NSMaxRange(nextRange) <= [[self textStorage] length]) {
@@ -222,8 +221,8 @@ static NSString *JSTQuotedStringAttributeName = @"JSTQuotedString";
     
     [self setLastAutoInsert:nil];
     
-    [super insertText:insertString];
-    
+    [super insertText:insertString replacementRange:replacementRange];
+
     NSRange currentRange = [self selectedRange];
     NSRange r = [self selectionRangeForProposedRange:currentRange granularity:NSSelectByParagraph];
     BOOL atEndOfLine = (NSMaxRange(r) - 1 == NSMaxRange(currentRange));


### PR DESCRIPTION
Code review for Allow scripts to register for individual actions (#8195):

> Right now (as of #7578) they just register any interest in any action, which means that they might get called a lot - which could be very bad for performance.
> 
> Instead we should allow scripts to list, in their manifest, the specific actions that they are interested in.
> 
> We might also want to allow scripts to register for a wildcard action, but probably only for debugging purposes. It's a good way to discover what actions are being sent, but a really bad idea from the performance point of view.

Connect to BohemianCoding/Sketch#8195.
