### PR TITLE
Code Review: Crash in Cocoascript in Sketch Beta 39 b5 (#9890)

### DIFF
--- a/src/framework/mocha/Objects/MOBox.h
+++ b/src/framework/mocha/Objects/MOBox.h
@@ -14,7 +14,7 @@
 @class MOBoxManager;
 
 #if DEBUG
-    #define DEBUG_CRASHES 1
+    #define MOCHA_DEBUG_CRASHES 1
 #endif
 
 /*!
@@ -50,7 +50,7 @@
  */
 @property (weak, readonly) MOBoxManager *manager;
 
-#if DEBUG_CRASHES
+#if MOCHA_DEBUG_CRASHES
 @property (strong) NSString *representedObjectCanaryDesc;
 @property (assign) NSUInteger count;
 #endif

--- a/src/framework/mocha/Objects/MOBox.h
+++ b/src/framework/mocha/Objects/MOBox.h
@@ -14,6 +14,8 @@
 @class MOBoxManager;
 
 #if DEBUG
+    // When this is set to 1, we add some extra book keeping objects to every box,
+    // to assist with debugging.
     #define MOCHA_DEBUG_CRASHES 1
 #endif
 
@@ -51,8 +53,19 @@
 @property (weak, readonly) MOBoxManager *manager;
 
 #if MOCHA_DEBUG_CRASHES
-@property (strong) NSString *representedObjectCanaryDesc;
-@property (assign) NSUInteger count;
+
+/**
+  A snapshot of the description of the object that the box is for, at
+  the time that it was first created.
+ */
+@property (readonly, strong) NSString *representedObjectCanaryDesc;
+
+/**
+  A global instance counter, helpful for tracking the box through
+  various bits of logging output.
+ */
+
+@property (readonly, assign) NSUInteger count;
 #endif
 
 @end

--- a/src/framework/mocha/Objects/MOBox.m
+++ b/src/framework/mocha/Objects/MOBox.m
@@ -14,9 +14,10 @@
 
 @implementation MOBox
 
-#if DEBUG_CRASHES
+#if MOCHA_DEBUG_CRASHES
 static NSUInteger initCount = 0;
 #endif
+
 
 
 - (id)initWithManager:(MOBoxManager *)manager object:(id)object jsObject:(JSObjectRef)jsObject {
@@ -25,7 +26,7 @@ static NSUInteger initCount = 0;
         NSAssert(manager != nil, @"valid manager");
         _manager = manager;
         _representedObject = object;
-#if DEBUG_CRASHES
+#if MOCHA_DEBUG_CRASHES
         _representedObjectCanaryDesc = [NSString stringWithFormat:@"box: %p\nobject: %p %@\njs object: %p\nboxed at: %@\n", self, object, object, jsObject, [NSDate date]];
         _count = initCount++;
 #endif
@@ -38,7 +39,7 @@ static NSUInteger initCount = 0;
 }
 
 - (void)disassociateObject {
-#if DEBUG_CRASHES
+#if MOCHA_DEBUG_CRASHES
     debug(@"dissassociated %p %ld", self, _count);
 #else
     debug(@"dissassociated %p", self);
@@ -53,7 +54,7 @@ static NSUInteger initCount = 0;
         _representedObject = nil;
         _manager = nil;
     } else {
-#if DEBUG_CRASHES
+#if MOCHA_DEBUG_CRASHES
         debug(@"shouldn't have been disassociated already %@", _representedObjectCanaryDesc);
 #else
         debug(@"shouldn't have been disassociated already %@", _representedObject);
@@ -62,13 +63,13 @@ static NSUInteger initCount = 0;
 }
 
 - (void)dealloc {
-#if DEBUG_CRASHES
+#if MOCHA_DEBUG_CRASHES
     debug(@"dealloced %p %ld", self, _count);
 #else
     debug(@"dealloced %p", self);
 #endif
     if (_manager || _JSObject) {
-#if DEBUG_CRASHES
+#if MOCHA_DEBUG_CRASHES
         debug(@"box should have been disassociated for %@", _representedObjectCanaryDesc);
 #else
         debug(@"box should have been disassociated for %@", _representedObject);


### PR DESCRIPTION
Code review for Crash in Cocoascript in Sketch Beta 39 b5 (#9890):

> From David at InVision (via @bomberstudios):
> 
> > Are you aware of any memory related bug introduced with beta 5 that you will be fixing?  I'm having trouble pinpointing the exact reason why some code in a plugin is causing the entire Sketch app to crash in JavaScript Core.  Adding some statements to log the variables that appear to cause the crash will prevent it from crashing which leads me to believe it is memory related (memory freeing when it shouldn't and/or corrupting memory).
> 
> **Notes**
> - @bomberstudios has requested further details and sample code from David
> - Almost certainly reintroduced as part of #9844 that included a proposed fix for #3019
> - Potential dupe of #3019

Connect to BohemianCoding/Sketch#9890.
