### PR TITLE
Code Review: Solve false Xcode 9.4 build warning (#18754)

### DIFF
--- a/Cocoa Script.xcodeproj/project.pbxproj
+++ b/Cocoa Script.xcodeproj/project.pbxproj
@@ -1434,7 +1434,7 @@
 		2A37F4A9FDCFA73011CA2CEA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0920;
+				LastUpgradeCheck = 0940;
 				TargetAttributes = {
 					9FC343C61AF7D2FE00B53759 = {
 						CreatedOnToolsVersion = 6.3.1;


### PR DESCRIPTION
Code review for BohemianCoding/Sketch#18754 (“Solve false Xcode 9.4 build warning”):



Connect to BohemianCoding/Sketch#18754.