### PR TITLE
Hardcode the port for plugins to listen on

### DIFF
--- a/src/framework/COSListener.m
+++ b/src/framework/COSListener.m
@@ -35,7 +35,8 @@
 
 
 - (void)setupListener {
-    NSString *myBundleId    = [[NSBundle mainBundle] bundleIdentifier];
+    // Hardcode the port to listen on because of sandboxing
+    NSString *myBundleId = @"WUGMZZ5K46.com.bohemiancoding";
     NSString *port          = [NSString stringWithFormat:@"%@.JSTalk", myBundleId];
 
 #pragma clang diagnostic push


### PR DESCRIPTION
Because of sandboxing the port to listen on has a very strict format.

See https://stackoverflow.com/a/62355568 and https://github.com/sketch-hq/Sketch/issues/52750