### PR TITLE
JSTTextView : Don't automatically skip the built-in `-deleteBackward:` handling if the delegate merely implements `-textView:doCommandBySelector:`

### DIFF
--- a/src/editor/JSTTextView.m
+++ b/src/editor/JSTTextView.m
@@ -569,57 +569,56 @@ static NSString *JSTQuotedStringAttributeName = @"JSTQuotedString";
             return;
         }
     }
-    else {
-        NSRange charRange = [self rangeForUserTextChange];
-        if (charRange.location != NSNotFound) {
-            if (charRange.length > 0) {
-                // Non-zero selection.  Delete normally.
+
+    NSRange charRange = [self rangeForUserTextChange];
+    if (charRange.location != NSNotFound) {
+        if (charRange.length > 0) {
+            // Non-zero selection.  Delete normally.
+            [super deleteBackward:sender];
+        } else {
+            if (charRange.location == 0) {
+                // At beginning of text.  Delete normally.
                 [super deleteBackward:sender];
             } else {
-                if (charRange.location == 0) {
-                    // At beginning of text.  Delete normally.
+                NSString *string = [self string];
+                NSRange paraRange = [string lineRangeForRange:NSMakeRange(charRange.location - 1, 1)];
+                if (paraRange.location == charRange.location) {
+                    // At beginning of line.  Delete normally.
                     [super deleteBackward:sender];
                 } else {
-                    NSString *string = [self string];
-                    NSRange paraRange = [string lineRangeForRange:NSMakeRange(charRange.location - 1, 1)];
-                    if (paraRange.location == charRange.location) {
-                        // At beginning of line.  Delete normally.
+                    unsigned tabWidth = 4; //[[TEPreferencesController sharedPreferencesController] tabWidth];
+                    unsigned indentWidth = 4;// [[TEPreferencesController sharedPreferencesController] indentWidth];
+                    BOOL usesTabs = NO; //[[TEPreferencesController sharedPreferencesController] usesTabs];
+                    NSRange leadingSpaceRange = paraRange;
+                    unsigned leadingSpaces = TE_numberOfLeadingSpacesFromRangeInString(string, &leadingSpaceRange, tabWidth);
+
+                    if (charRange.location > NSMaxRange(leadingSpaceRange)) {
+                        // Not in leading whitespace.  Delete normally.
                         [super deleteBackward:sender];
                     } else {
-                        unsigned tabWidth = 4; //[[TEPreferencesController sharedPreferencesController] tabWidth];
-                        unsigned indentWidth = 4;// [[TEPreferencesController sharedPreferencesController] indentWidth];
-                        BOOL usesTabs = NO; //[[TEPreferencesController sharedPreferencesController] usesTabs];
-                        NSRange leadingSpaceRange = paraRange;
-                        unsigned leadingSpaces = TE_numberOfLeadingSpacesFromRangeInString(string, &leadingSpaceRange, tabWidth);
-                        
-                        if (charRange.location > NSMaxRange(leadingSpaceRange)) {
-                            // Not in leading whitespace.  Delete normally.
-                            [super deleteBackward:sender];
-                        } else {
-                            NSTextStorage *text = [self textStorage];
-                            unsigned leadingIndents = leadingSpaces / indentWidth;
-                            NSString *replaceString;
-                            
-                            // If we were indented to an fractional level just go back to the last even multiple of indentWidth, if we were exactly on, go back a full level.
-                            if (leadingSpaces % indentWidth == 0) {
-                                leadingIndents--;
+                        NSTextStorage *text = [self textStorage];
+                        unsigned leadingIndents = leadingSpaces / indentWidth;
+                        NSString *replaceString;
+
+                        // If we were indented to an fractional level just go back to the last even multiple of indentWidth, if we were exactly on, go back a full level.
+                        if (leadingSpaces % indentWidth == 0) {
+                            leadingIndents--;
+                        }
+                        leadingSpaces = leadingIndents * indentWidth;
+                        replaceString = ((leadingSpaces > 0) ? TE_tabbifiedStringWithNumberOfSpaces(leadingSpaces, tabWidth, usesTabs) : @"");
+                        if ([self shouldChangeTextInRange:leadingSpaceRange replacementString:replaceString]) {
+                            NSDictionary *newTypingAttributes;
+                            if (charRange.location < [string length]) {
+                                newTypingAttributes = [text attributesAtIndex:charRange.location effectiveRange:NULL];
+                            } else {
+                                newTypingAttributes = [text attributesAtIndex:(charRange.location - 1) effectiveRange:NULL];
                             }
-                            leadingSpaces = leadingIndents * indentWidth;
-                            replaceString = ((leadingSpaces > 0) ? TE_tabbifiedStringWithNumberOfSpaces(leadingSpaces, tabWidth, usesTabs) : @"");
-                            if ([self shouldChangeTextInRange:leadingSpaceRange replacementString:replaceString]) {
-                                NSDictionary *newTypingAttributes;
-                                if (charRange.location < [string length]) {
-                                    newTypingAttributes = [text attributesAtIndex:charRange.location effectiveRange:NULL];
-                                } else {
-                                    newTypingAttributes = [text attributesAtIndex:(charRange.location - 1) effectiveRange:NULL];
-                                }
-                                
-                                [text replaceCharactersInRange:leadingSpaceRange withString:replaceString];
-                                
-                                [self setTypingAttributes:newTypingAttributes];
-                                
-                                [self didChangeText];
-                            }
+
+                            [text replaceCharactersInRange:leadingSpaceRange withString:replaceString];
+
+                            [self setTypingAttributes:newTypingAttributes];
+
+                            [self didChangeText];
                         }
                     }
                 }


### PR DESCRIPTION
A bug in `-[JSTTextView deleteBackward:]` prevents the built-in handling of this command if the text view delegate _implements_ `-textView:doCommandBySelector:`, not if it actually _responds_ with `YES`:

```swift
if (delegate.respondsToSelector(...)) {
    if (delegate.textView(self, doCommandBy: ...) {
        // The delegate took care of this command; skip the default handling.
        return;
    }
    //
    // 💥 Nothing happens if the delegate returns NO: there's no fallthrough
    //     to the `else` clause below.
    //
}
else {
    // The built-in handling of the `deleteBackward` command.
}
```

This PR removes the unintended `else` clause around the built-in command handling code. The rest of the changes are whitespace-only.