### PR TITLE
Add support for JS template literals

### DIFF
--- a/src/framework/todparsekit/TDTokenizer.m
+++ b/src/framework/todparsekit/TDTokenizer.m
@@ -71,7 +71,7 @@
         [self addTokenizerState:symbolState     from:  58 to:  64];
         [self addTokenizerState:wordState       from: 'A' to: 'Z']; // From: 65 to: 90    From:0x41 to:0x5A
         [self addTokenizerState:symbolState     from:  91 to:  95];
-        [self addTokenizerState:quoteState      from:'`'  to: '`']; // From: 96 to: 96    From:0x60 to:0x60
+        [self addTokenizerState:quoteState      from: '`' to: '`']; // From: 96 to: 96    From:0x60 to:0x60
         [self addTokenizerState:wordState       from: 'a' to: 'z']; // From: 97 to:122    From:0x61 to:0x7A
         [self addTokenizerState:symbolState     from: 123 to: 191];
         [self addTokenizerState:wordState       from:0xC0 to:0xFF]; // From:192 to:255    From:0xC0 to:0xFF

--- a/src/framework/todparsekit/TDTokenizer.m
+++ b/src/framework/todparsekit/TDTokenizer.m
@@ -70,7 +70,8 @@
         [self addTokenizerState:numberState     from: '0' to: '9']; // From: 48 to: 57    From:0x30 to:0x39
         [self addTokenizerState:symbolState     from:  58 to:  64];
         [self addTokenizerState:wordState       from: 'A' to: 'Z']; // From: 65 to: 90    From:0x41 to:0x5A
-        [self addTokenizerState:symbolState     from:  91 to:  96];
+        [self addTokenizerState:symbolState     from:  91 to:  95];
+        [self addTokenizerState:quoteState      from:'`'  to: '`']; // From: 96 to: 96    From:0x60 to:0x60
         [self addTokenizerState:wordState       from: 'a' to: 'z']; // From: 97 to:122    From:0x61 to:0x7A
         [self addTokenizerState:symbolState     from: 123 to: 191];
         [self addTokenizerState:wordState       from:0xC0 to:0xFF]; // From:192 to:255    From:0xC0 to:0xFF


### PR DESCRIPTION
This makes `JSTTextView` properly highlight JavaScript template literals (aka "backtick strings") as actual strings:

```js
const str = `this is a string that supports templates like 2+2 = ${2+2}`
console.log(str)
```