### PR TITLE
SMAC-8850 Do not replace trailing `id` tokens with `var` during preprocessing

### DIFF
--- a/src/framework/COSPreprocessor.m
+++ b/src/framework/COSPreprocessor.m
@@ -115,7 +115,6 @@
         [type isEqualToString:@"long"]        ||
         [type isEqualToString:@"NSInteger"]   ||
         [type isEqualToString:@"NSUInteger"]  ||
-        [type isEqualToString:@"id"]          ||
         [type isEqualToString:@"bool"]        ||
         [type isEqualToString:@"BOOL"]        ||
         [type isEqualToString:@"int"])


### PR DESCRIPTION
There's a bug (?) in `-[COSPreprocessor preprocessForObjCMessagesToJS:]` that makes CocoaScript replace all _trailing_ `id` tokens with `var`.

### Steps to reproduce

1. Open a Sketch document and run the following script:
    ```js
    const identifier = require('sketch').getSelectedDocument().id
    console.log(identifier)
    ``` 

   This will print `undefined` even though all documents have an identifier.

2. Next, run the following script:
    ```js
    console.log(require('sketch').getSelectedDocument().id)
    ```

     This will successfully print the expected identifier string.

3. Next, let's get back to the original script and try to call `id` as if it was a method:

    ```js
    const identifier = require('sketch').getSelectedDocument().id()
    console.log(identifier)
    ```

      This will print raise the following error, note the unexpected **var** bit:
   
     > TypeError: require('sketch').getSelectedDocument()**.var** is not a function.


### Why this happens

A helper routine `-[COSPreprocessor fixTypeToVar:]` replaces Objective-C types (like `CGFloat`, `double`, or `id`) with a `var, so the resulting code is valid JavaScript:

```js
// before (this is basically pure Objective-C ❌)
id myValue = 0.5;
// after (this is now valid JavaScript ✅)
var myValue = 0.5;
```

### The proposed fix

This PR removes `id` from the type replacement table. This is more of a workaround than a proper solution, but rethinking CocoaScript code preprocessing pipeline is not feasible at the moment.